### PR TITLE
Optimize HPL and MPICH further

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -46,9 +46,12 @@
         chdir: "{{ hpl_root }}/tmp/mpich-{{ mpich_version }}"
         creates: "{{ hpl_root }}/tmp/COMPILE_MPI_COMPLETE"
       environment:
-        - FFLAGS: "-fallow-argument-mismatch"
+        - CFLAGS: "-flto=auto -mtune=native"
+        - CXXFLAGS: "-flto=auto -mtune=native"
+        - FFLAGS: "-fallow-argument-mismatch -flto=auto -mtune=native"
+        - LDFLAGS: "-flto=auto -mtune=native"
       loop:
-        - ./configure --prefix="{{ hpl_root }}/mpich" --with-device=ch3:sock
+        - ./configure --enable-fast=O3,ndebug --enable-g=none --prefix="{{ hpl_root }}/mpich" --with-device=ch3:sock
         - "make -j{{ ansible_processor_nproc }}"
 
     - name: Install MPI.

--- a/templates/benchmark-Make.top500.j2
+++ b/templates/benchmark-Make.top500.j2
@@ -166,7 +166,7 @@ HPL_LIBS     = $(HPLlib) $(LAlib) $(MPlib)
 #    *) call the BLAS Fortran 77 interface,
 #    *) not display detailed timing information.
 #
-HPL_OPTS     =
+HPL_OPTS     = -flto=auto -mtune=native -O3
 #
 # ----------------------------------------------------------------------
 #
@@ -181,7 +181,7 @@ CCNOOPT      = $(HPL_DEFS)
 CCFLAGS      = $(HPL_DEFS)
 #
 LINKER       = {{ hpl_root }}/mpich/bin/mpif77
-LINKFLAGS    =
+LINKFLAGS    = $(HPL_OPTS)
 #
 ARCHIVER     = ar
 ARFLAGS      = r


### PR DESCRIPTION
HPL spends the majority of its execution time inside the BLAS implementation, so these changes affect mainly slower processors such as in-order ones.

Note that link-time optimization (i.e. the `-flto` option) increases both build time and memory consumption during linking by a non-trivial amount. As a reminder, the `-march=native` parameter behaves differently on AArch64 and x86-64, for example, especially with older compilers such as GCC up to and including version 14, so ideally we would combine it with `-mtune=native` as futureproofing. However, in my experiments it didn't lead to any further significant performance difference, while all 20 runs that I tried failed the residual check, so I decided to omit it.

I benchmarked my changes on a Radxa Orion O6 board by doing 20 runs with the `Qs` parameter set to `12` and `blis_configure_options` - to `cortexa57`. Here are my results:

Revision|Successful runs|Median Gflops|Standard error|Minimum Gflops|Maximum Gflops
-|-|-|-|-|-|
2c2d4553962b5d88ad100b656db58355992b3f17|7|88.03|0.22|87.15|89.02
My changes|10|89.52|0.20|88.46|90.49

In other words, an approximately 1.69% improvement. For comparison, on an AMD Ryzen 9 5900X-based machine with 64 GiB RAM there was no significant difference.