### PR TITLE
Use the -march=native option when building HPL and MPICH

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -46,10 +46,10 @@
         chdir: "{{ hpl_root }}/tmp/mpich-{{ mpich_version }}"
         creates: "{{ hpl_root }}/tmp/COMPILE_MPI_COMPLETE"
       environment:
-        - CFLAGS: "-flto=auto -mtune=native"
-        - CXXFLAGS: "-flto=auto -mtune=native"
-        - FFLAGS: "-fallow-argument-mismatch -flto=auto -mtune=native"
-        - LDFLAGS: "-flto=auto -mtune=native"
+        - CFLAGS: "-flto=auto -march=native -mtune=native"
+        - CXXFLAGS: "-flto=auto -march=native -mtune=native"
+        - FFLAGS: "-fallow-argument-mismatch -flto=auto -march=native -mtune=native"
+        - LDFLAGS: "-flto=auto -march=native -mtune=native"
       loop:
         - ./configure --enable-fast=O3,ndebug --enable-g=none --prefix="{{ hpl_root }}/mpich" --with-device=ch3:sock
         - "make -j{{ ansible_processor_nproc }}"

--- a/templates/benchmark-Make.top500.j2
+++ b/templates/benchmark-Make.top500.j2
@@ -166,7 +166,7 @@ HPL_LIBS     = $(HPLlib) $(LAlib) $(MPlib)
 #    *) call the BLAS Fortran 77 interface,
 #    *) not display detailed timing information.
 #
-HPL_OPTS     = -flto=auto -mtune=native -O3
+HPL_OPTS     = -flto=auto -march=native -mtune=native -O3
 #
 # ----------------------------------------------------------------------
 #


### PR DESCRIPTION
As I mentioned in pull request #70, these changes are mostly futureproofing, and I am fairly certain that the residual check failures that I was experiencing with the Radxa Orion O6 board were thermal issues. As a side note, the cooler that comes bundled with the board turned out to be inadequate, especially if the latter was installed in a case. The symptoms were lock-ups or thermal protection triggerring inside the Linux kernel, which would lead to system shutdown. At best, the residual check at the end of the HPL execution would fail.