### PR TITLE
Revert "Use the -march=native option when building HPL and MPICH"

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -46,10 +46,10 @@
         chdir: "{{ hpl_root }}/tmp/mpich-{{ mpich_version }}"
         creates: "{{ hpl_root }}/tmp/COMPILE_MPI_COMPLETE"
       environment:
-        - CFLAGS: "-flto=auto -march=native -mtune=native"
-        - CXXFLAGS: "-flto=auto -march=native -mtune=native"
-        - FFLAGS: "-fallow-argument-mismatch -flto=auto -march=native -mtune=native"
-        - LDFLAGS: "-flto=auto -march=native -mtune=native"
+        - CFLAGS: "-flto=auto -mtune=native"
+        - CXXFLAGS: "-flto=auto -mtune=native"
+        - FFLAGS: "-fallow-argument-mismatch -flto=auto -mtune=native"
+        - LDFLAGS: "-flto=auto -mtune=native"
       loop:
         - ./configure --enable-fast=O3,ndebug --enable-g=none --prefix="{{ hpl_root }}/mpich" --with-device=ch3:sock
         - "make -j{{ ansible_processor_nproc }}"

--- a/templates/benchmark-Make.top500.j2
+++ b/templates/benchmark-Make.top500.j2
@@ -166,7 +166,7 @@ HPL_LIBS     = $(HPLlib) $(LAlib) $(MPlib)
 #    *) call the BLAS Fortran 77 interface,
 #    *) not display detailed timing information.
 #
-HPL_OPTS     = -flto=auto -march=native -mtune=native -O3
+HPL_OPTS     = -flto=auto -mtune=native -O3
 #
 # ----------------------------------------------------------------------
 #


### PR DESCRIPTION
Reverts geerlingguy/top500-benchmark#71

Reverting these changes for the time being—with them in, builds on RISC-V systems fail. See:

  - [GCC RISC-V Options](https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Options.html)
  - [ISA string must begin with rv32 or rv64](https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1505)

cc @volyrique 